### PR TITLE
Disables gemnasium autoupdate, which has been failing for months.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,14 +33,4 @@ database:
 
 test:
   override:
-    - >
-      if [ -n "${RUN_GEMNASIUM_AUTOUPDATE}" ]; then
-        gem install bundler
-        sudo sh -c 'echo "deb http://apt.gemnasium.com stable main" > /etc/apt/sources.list.d/gemnasium.list'
-        sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com E5CEAB0AC5F1CA2A
-        sudo apt-get update
-        sudo apt-get install gemnasium-toolbelt
-        gemnasium autoupdate run
-      else
-        script/cibuild
-      fi
+    - script/cibuild


### PR DESCRIPTION
Its been failing with a strange '404 Not Found: Commit not found.' error.

Open Issue: https://github.com/dobtco/screendoor-v2/issues/4420